### PR TITLE
All-at-once PCA cross-validation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -337,19 +337,19 @@ files = [
 
 [[package]]
 name = "filelock"
-version = "3.11.0"
+version = "3.12.0"
 description = "A platform independent file lock."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "filelock-3.11.0-py3-none-any.whl", hash = "sha256:f08a52314748335c6460fc8fe40cd5638b85001225db78c2aa01c8c0db83b318"},
-    {file = "filelock-3.11.0.tar.gz", hash = "sha256:3618c0da67adcc0506b015fd11ef7faf1b493f0b40d87728e19986b536890c37"},
+    {file = "filelock-3.12.0-py3-none-any.whl", hash = "sha256:ad98852315c2ab702aeb628412cbf7e95b7ce8c3bf9565670b4eaecf1db370a9"},
+    {file = "filelock-3.12.0.tar.gz", hash = "sha256:fc03ae43288c013d2ea83c8597001b1129db351aad9c57fe2409327916b8e718"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.2.2)", "diff-cover (>=7.5)", "pytest (>=7.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2023.3.27)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "fonttools"
@@ -1274,13 +1274,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pynndescent"
-version = "0.5.8"
+version = "0.5.10"
 description = "Nearest Neighbor Descent"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pynndescent-0.5.8.tar.gz", hash = "sha256:a7c552569bf604a101fd54bba1d27c12389e065945dee3a6777a518c63a46f2b"},
+    {file = "pynndescent-0.5.10.tar.gz", hash = "sha256:5d5dc683c03ef55fe3ddf693859720ca18f85c6e6e5bb0b4f14870278d5288ad"},
 ]
 
 [package.dependencies]
@@ -1496,14 +1496,14 @@ scipy = ">=1.0"
 
 [[package]]
 name = "setuptools"
-version = "67.6.1"
+version = "67.7.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.6.1-py3-none-any.whl", hash = "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"},
-    {file = "setuptools-67.6.1.tar.gz", hash = "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a"},
+    {file = "setuptools-67.7.1-py3-none-any.whl", hash = "sha256:6f0839fbdb7e3cfef1fc38d7954f5c1c26bf4eebb155a55c9bf8faf997b9fb67"},
+    {file = "setuptools-67.7.1.tar.gz", hash = "sha256:bb16732e8eb928922eabaa022f881ae2b7cdcfaf9993ef1f5e841a96d32b8e0c"},
 ]
 
 [package.extras]

--- a/sccp/tests/test_CrossVal.py
+++ b/sccp/tests/test_CrossVal.py
@@ -8,11 +8,11 @@ from ..crossVal import crossvalidate, crossvalidate_PCA
 
 def test_crossval():
     """Test for correctness of cross validation."""
-    rank = 3
+    rank = 5
     X = random_parafac2([(100, 200)] * 5, rank=rank, full=True)
 
-    pca_err = crossvalidate_PCA(np.concatenate(X, axis=0), rank=rank, trainPerc=0.8)
-    assert pca_err > 0.95
+    pca_err = crossvalidate_PCA(np.concatenate(X), rank=rank, trainPerc=0.8)
+    assert pca_err[-1] > 0.95
 
     err = crossvalidate(X, rank=rank, trainPerc=0.8)
     assert err > 0.95


### PR DESCRIPTION
I very much doubt the PCA cross-validation is very slow, but just in case, this calculates the result for all ranks at once. This potentially could be easier to diagnose later on if there are problems, because it provides the results for all ranks and the same held-out data.