### PR TITLE
plot ROC AUC across cv folds

### DIFF
--- a/sccp/figures/common.py
+++ b/sccp/figures/common.py
@@ -19,6 +19,9 @@ from os.path import join
 from pandas.plotting import parallel_coordinates as pc
 import pickle
 from matplotlib.patches import Patch
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import RocCurveDisplay, auc
+from sklearn.model_selection import StratifiedGroupKFold
 
 path_here = os.path.dirname(os.path.dirname(__file__))
 
@@ -610,3 +613,83 @@ def investigate_comp(comp: int, rank: int, obs, proj_B, obs_column, ax, threshol
     sns.barplot(pcts, x = obs_column, y = 'percent', errorbar=None, ax=ax)
     ax.tick_params(axis="x", rotation=90)
     ax.set_title(obs_column + ' Percentages, Threshold: ' + str(threshold) + ' for comp ' + str(comp))
+
+def plotROCAcrossGroups(A_matrix, group_labs, ax, 
+                        pred_group = 'SLE_status',
+                        cv_group = 'Processing_Cohort',
+                        penalty_type = 'l1',      
+                        solver = 'saga',
+                        penalty = 50,
+                        n_splits = 4):    
+    
+    condition_labels_all = group_labs
+
+    condition_labels = group_labs[pred_group]
+       
+    sgkf = StratifiedGroupKFold(n_splits=n_splits)
+    
+    # get labels for the group that you want to do cross validation by 
+    group_cond_labels = condition_labels_all[cv_group]
+    # set up log reg specs
+    log_reg = LogisticRegression(random_state=0, 
+                                 max_iter = 5000,
+                                 penalty = penalty_type, 
+                                 solver = solver,
+                                 C = penalty
+                                 ) 
+
+    tprs = []
+    aucs = []
+    mean_fpr = np.linspace(0, 1, 100)
+
+    for fold, (train, test) in enumerate(sgkf.split(A_matrix, condition_labels.to_numpy(), group_cond_labels.to_numpy())):
+        log_reg.fit(A_matrix[train], condition_labels.to_numpy()[train])
+        viz = RocCurveDisplay.from_estimator(
+            log_reg,
+            A_matrix[test],
+            condition_labels.to_numpy()[test],
+            name=f"ROC fold {fold}",
+            alpha=0.3,
+            lw=1,
+            ax=ax,
+            plot_chance_level=(fold == n_splits - 1),
+        )
+    interp_tpr = np.interp(mean_fpr, viz.fpr, viz.tpr)
+    interp_tpr[0] = 0.0
+    tprs.append(interp_tpr)
+    aucs.append(viz.roc_auc)
+
+    mean_tpr = np.mean(tprs, axis=0)
+    mean_tpr[-1] = 1.0
+    mean_auc = auc(mean_fpr, mean_tpr)
+    std_auc = np.std(aucs)
+    ax.plot(
+        mean_fpr,
+        mean_tpr,
+        color="b",
+        label=r"Mean ROC (AUC = %0.2f $\pm$ %0.2f)" % (mean_auc, std_auc),
+        lw=2,
+        alpha=0.8,
+    )
+
+    std_tpr = np.std(tprs, axis=0)
+    tprs_upper = np.minimum(mean_tpr + std_tpr, 1)
+    tprs_lower = np.maximum(mean_tpr - std_tpr, 0)
+    ax.fill_between(
+    mean_fpr,
+    tprs_lower,
+    tprs_upper,
+    color="grey",
+    alpha=0.2,
+    label=r"$\pm$ 1 std. dev.",
+    )
+
+    ax.set(
+        xlim=[-0.05, 1.05],
+        ylim=[-0.05, 1.05],
+        xlabel="False Positive Rate",
+        ylabel="True Positive Rate",
+        title="Mean ROC curve with variability",
+    )
+    ax.axis("square")
+    ax.legend(loc="lower right")

--- a/sccp/figures/figureS3cv2.py
+++ b/sccp/figures/figureS3cv2.py
@@ -1,0 +1,51 @@
+"""
+S3b: Logistic Regression (and maybe SVM) on Pf2 Factor matrix A output
+article: https://www.science.org/doi/10.1126/science.abf1970
+data: https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE174188
+"""
+
+# GOAL: run logisitc regression to see which components are best able to predict disease status
+
+# load functions/modules ----
+from .common import (
+    subplotLabel,
+    getSetup,
+    openPf2,
+    plotROCAcrossGroups
+)
+from ..imports.scRNA import load_lupus_data
+
+
+def makeFigure():
+    """Get a list of the axis objects and create a figure."""
+    # Get list of axis objects
+    ax, f = getSetup((12, 6), # fig size
+                     (1, 1) # grid size
+                     )
+
+    # Add subplot labels
+    subplotLabel(ax)
+
+    rank = 40
+
+
+    _, factors, _ = openPf2(rank = rank, dataName = 'lupus', optProjs=True)
+
+    _, obs = load_lupus_data() 
+
+    status = (
+              obs[['sample_ID', 'SLE_status', 'Processing_Cohort']]
+             .drop_duplicates()
+              )
+    
+    group_labs = status.set_index('sample_ID')[['SLE_status', 'Processing_Cohort']]
+        
+    A_matrix = factors[0]   
+
+
+    plotROCAcrossGroups(A_matrix, group_labs, ax[0],
+                        pred_group='SLE_status',
+                        cv_group='Processing_Cohort')
+
+    
+    return f


### PR DESCRIPTION
Creates a plot of the ROC AUC across multiple different folds, currently uses `sklearn.model_selection.StratifiedGroupKFold` to make folds that correspond to each processing batch. Open to suggestions on how to split this into two functions (one for `common` and one for `logisitcReg`, but I was hesitant to break up the for loop that fits each model while making each curve. One other concern was the fact that one fold will never have an auc (since one group has no SLE cases)-- but if we want to make groups that are processing batches I don't see a way around that. Here is the figure now:

![figureS3cv2](https://github.com/meyer-lab/scCP/assets/126696611/c08d3ea9-1079-4f61-8481-9b727c72a899)

