### PR TITLE
fixing ROC AUC across folds

### DIFF
--- a/sccp/figures/common.py
+++ b/sccp/figures/common.py
@@ -649,6 +649,11 @@ def plotROCAcrossGroups(A_matrix, group_labs, ax,
     mean_fpr = np.linspace(0, 1, 100)
 
     for fold, (train, test) in enumerate(sgkf.split(A_matrix, condition_labels.to_numpy(), group_cond_labels.to_numpy())):
+        # adding escape option for the second fold (@ index 1) because it has no SLE cases.
+        # otherwise we just get NA for our mean and NA for that fold. which isn't super helpful
+        # this if statement shouldn't be used with other data
+        if fold == 1:
+            continue
         log_reg.fit(A_matrix[train], condition_labels.to_numpy()[train])
         viz = RocCurveDisplay.from_estimator(
             log_reg,
@@ -660,10 +665,10 @@ def plotROCAcrossGroups(A_matrix, group_labs, ax,
             ax=ax,
             plot_chance_level=(fold == n_splits - 1),
         )
-    interp_tpr = np.interp(mean_fpr, viz.fpr, viz.tpr)
-    interp_tpr[0] = 0.0
-    tprs.append(interp_tpr)
-    aucs.append(viz.roc_auc)
+        interp_tpr = np.interp(mean_fpr, viz.fpr, viz.tpr)
+        interp_tpr[0] = 0.0
+        tprs.append(interp_tpr)
+        aucs.append(viz.roc_auc)
 
     mean_tpr = np.mean(tprs, axis=0)
     mean_tpr[-1] = 1.0


### PR DESCRIPTION
was anyone else wondering why this plot always had a mean ROC curve despite the fact that one of the entries it was taking the mean of was NA and that that mean curve always correlated perfectly with a standard deviation of 0.00 with the last fitted model? (below:)
![figureS3cv2](https://github.com/meyer-lab/scCP/assets/126696611/34e872fd-999f-4f7c-8ccf-66750f5d9707)

I was ! anyways when I copied this code from the internet I accidentally unindented like 4 lines so part of what should've been included in the for loop was just getting run on the last part of the for loop. Fixed this so it all runs; and so that the curve just isn't generated for the fold that doesn't have any SLE cases (to avoid carrying through an NA):
![figureS3cv2_REALCORRECT](https://github.com/meyer-lab/scCP/assets/126696611/b10fed40-2d71-4c03-b76f-93d3d692d342)
