### PR TITLE
Always use datashader for UMAP plots

### DIFF
--- a/sccp/figures/figureCITEseq1.py
+++ b/sccp/figures/figureCITEseq1.py
@@ -7,8 +7,7 @@ from .commonFuncs.plotFactors import (
 )
 import umap
 from ..imports.citeseq import import_citeseq
-import umap.plot
-import numpy as np
+from .commonFuncs.plotUMAP import points
 
 
 def makeFigure():
@@ -28,7 +27,7 @@ def makeFigure():
 
     pf2Points = umap.UMAP(random_state=1).fit(projs)
 
-    umap.plot.points(
+    points(
         pf2Points,
         labels=protDF["Condition"].values,
         ax=ax[3],


### PR DESCRIPTION
Datashader is faster to plot, provides a more accurate plot in the end, and this also avoids ending up with SVG files that are too complex to open. I just copied `umap.plot.points` into the package, removing some of the options we should never change.