### PR TITLE
Switch to PaCMAP

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -25,6 +25,17 @@ doc = ["IPython", "awkward (>=2.0.7)", "myst_parser", "nbsphinx", "scanpydoc[the
 test = ["awkward (>=2.3)", "boltons", "dask[array]", "joblib", "loompy (>=3.0.5)", "matplotlib", "openpyxl", "pytest (>=6.0)", "pytest-cov (>=2.10)", "pytest_memray", "scanpy", "scikit-learn", "zarr"]
 
 [[package]]
+name = "annoy"
+version = "1.17.3"
+description = "Approximate Nearest Neighbors in C++/Python optimized for memory usage and loading/saving to disk."
+optional = false
+python-versions = "*"
+files = [
+    {file = "annoy-1.17.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c33a5d4d344c136c84976bfb2825760142a8bb25335165e24e11c9afbfa8c2e9"},
+    {file = "annoy-1.17.3.tar.gz", hash = "sha256:9cbfebefe0a5f843eba29c6be4c84d601f4f41ad4ded0486f1b88c3b07739c15"},
+]
+
+[[package]]
 name = "biothings-client"
 version = "0.3.0"
 description = "Python Client for BioThings API services."
@@ -42,46 +53,6 @@ requests = ">=2.3.0"
 caching = ["requests-cache (>=0.4.13)"]
 dataframe = ["pandas (>=0.18.0)"]
 jsonld = ["PyLD (>=0.7.2)"]
-
-[[package]]
-name = "bleach"
-version = "6.0.0"
-description = "An easy safelist-based HTML-sanitizing tool."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "bleach-6.0.0-py3-none-any.whl", hash = "sha256:33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4"},
-    {file = "bleach-6.0.0.tar.gz", hash = "sha256:1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414"},
-]
-
-[package.dependencies]
-six = ">=1.9.0"
-webencodings = "*"
-
-[package.extras]
-css = ["tinycss2 (>=1.1.0,<1.2)"]
-
-[[package]]
-name = "bokeh"
-version = "3.2.2"
-description = "Interactive plots and applications in the browser from Python"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "bokeh-3.2.2-py3-none-any.whl", hash = "sha256:e31670a013e1ff15c3d4d04f587c8162c4cc9fe1af507fd741d295e6c4e1225b"},
-    {file = "bokeh-3.2.2.tar.gz", hash = "sha256:b2959b8524d69ec4e7886bc36407445f0a92e1f19530d3bfc4045236a1b7a6ff"},
-]
-
-[package.dependencies]
-contourpy = ">=1"
-Jinja2 = ">=2.9"
-numpy = ">=1.16"
-packaging = ">=16.8"
-pandas = ">=1.2"
-pillow = ">=7.1.0"
-PyYAML = ">=3.10"
-tornado = ">=5.1"
-xyzservices = ">=2021.09.1"
 
 [[package]]
 name = "certifi"
@@ -417,13 +388,13 @@ toml = ["tomli"]
 
 [[package]]
 name = "cycler"
-version = "0.12.0"
+version = "0.12.1"
 description = "Composable style cycles"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "cycler-0.12.0-py3-none-any.whl", hash = "sha256:7896994252d006771357777d0251f3e34d266f4fa5f2c572247a80ab01440947"},
-    {file = "cycler-0.12.0.tar.gz", hash = "sha256:8cc3a7b4861f91b1095157f9916f748549a617046e67eb7619abed9b34d2c94a"},
+    {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
+    {file = "cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"},
 ]
 
 [package.extras]
@@ -537,53 +508,53 @@ typing = ["typing-extensions (>=4.7.1)"]
 
 [[package]]
 name = "fonttools"
-version = "4.43.0"
+version = "4.43.1"
 description = "Tools to manipulate font files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fonttools-4.43.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ab80e7d6bb01316d5fc8161a2660ca2e9e597d0880db4927bc866c76474472ef"},
-    {file = "fonttools-4.43.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:82d8e687a42799df5325e7ee12977b74738f34bf7fde1c296f8140efd699a213"},
-    {file = "fonttools-4.43.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d08a694b280d615460563a6b4e2afb0b1b9df708c799ec212bf966652b94fc84"},
-    {file = "fonttools-4.43.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d654d3e780e0ceabb1f4eff5a3c042c67d4428d0fe1ea3afd238a721cf171b3"},
-    {file = "fonttools-4.43.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:20fc43783c432862071fa76da6fa714902ae587bc68441e12ff4099b94b1fcef"},
-    {file = "fonttools-4.43.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:33c40a657fb87ff83185828c0323032d63a4df1279d5c1c38e21f3ec56327803"},
-    {file = "fonttools-4.43.0-cp310-cp310-win32.whl", hash = "sha256:b3813f57f85bbc0e4011a0e1e9211f9ee52f87f402e41dc05bc5135f03fa51c1"},
-    {file = "fonttools-4.43.0-cp310-cp310-win_amd64.whl", hash = "sha256:05056a8c9af048381fdb17e89b17d45f6c8394176d01e8c6fef5ac96ea950d38"},
-    {file = "fonttools-4.43.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:da78f39b601ed0b4262929403186d65cf7a016f91ff349ab18fdc5a7080af465"},
-    {file = "fonttools-4.43.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5056f69a18f3f28ab5283202d1efcfe011585d31de09d8560f91c6c88f041e92"},
-    {file = "fonttools-4.43.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dcc01cea0a121fb0c009993497bad93cae25e77db7dee5345fec9cce1aaa09cd"},
-    {file = "fonttools-4.43.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee728d5af70f117581712966a21e2e07031e92c687ef1fdc457ac8d281016f64"},
-    {file = "fonttools-4.43.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b5e760198f0b87e42478bb35a6eae385c636208f6f0d413e100b9c9c5efafb6a"},
-    {file = "fonttools-4.43.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:af38f5145258e9866da5881580507e6d17ff7756beef175d13213a43a84244e9"},
-    {file = "fonttools-4.43.0-cp311-cp311-win32.whl", hash = "sha256:25620b738d4533cfc21fd2a4f4b667e481f7cb60e86b609799f7d98af657854e"},
-    {file = "fonttools-4.43.0-cp311-cp311-win_amd64.whl", hash = "sha256:635658464dccff6fa5c3b43fe8f818ae2c386ee6a9e1abc27359d1e255528186"},
-    {file = "fonttools-4.43.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:a682fb5cbf8837d1822b80acc0be5ff2ea0c49ca836e468a21ffd388ef280fd3"},
-    {file = "fonttools-4.43.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3d7adfa342e6b3a2b36960981f23f480969f833d565a4eba259c2e6f59d2674f"},
-    {file = "fonttools-4.43.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5aa67d1e720fdd902fde4a59d0880854ae9f19fc958f3e1538bceb36f7f4dc92"},
-    {file = "fonttools-4.43.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77e5113233a2df07af9dbf493468ce526784c3b179c0e8b9c7838ced37c98b69"},
-    {file = "fonttools-4.43.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:57c22e5f9f53630d458830f710424dce4f43c5f0d95cb3368c0f5178541e4db7"},
-    {file = "fonttools-4.43.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:206808f9717c9b19117f461246372a2c160fa12b9b8dbdfb904ab50ca235ba0a"},
-    {file = "fonttools-4.43.0-cp312-cp312-win32.whl", hash = "sha256:f19c2b1c65d57cbea25cabb80941fea3fbf2625ff0cdcae8900b5fb1c145704f"},
-    {file = "fonttools-4.43.0-cp312-cp312-win_amd64.whl", hash = "sha256:7c76f32051159f8284f1a5f5b605152b5a530736fb8b55b09957db38dcae5348"},
-    {file = "fonttools-4.43.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e3f8acc6ef4a627394021246e099faee4b343afd3ffe2e517d8195b4ebf20289"},
-    {file = "fonttools-4.43.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a68b71adc3b3a90346e4ac92f0a69ab9caeba391f3b04ab6f1e98f2c8ebe88e3"},
-    {file = "fonttools-4.43.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ace0fd5afb79849f599f76af5c6aa5e865bd042c811e4e047bbaa7752cc26126"},
-    {file = "fonttools-4.43.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f9660e70a2430780e23830476332bc3391c3c8694769e2c0032a5038702a662"},
-    {file = "fonttools-4.43.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:48078357984214ccd22d7fe0340cd6ff7286b2f74f173603a1a9a40b5dc25afe"},
-    {file = "fonttools-4.43.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d27d960e10cf7617d70cf3104c32a69b008dde56f2d55a9bed4ba6e3df611544"},
-    {file = "fonttools-4.43.0-cp38-cp38-win32.whl", hash = "sha256:a6a2e99bb9ea51e0974bbe71768df42c6dd189308c22f3f00560c3341b345646"},
-    {file = "fonttools-4.43.0-cp38-cp38-win_amd64.whl", hash = "sha256:030355fbb0cea59cf75d076d04d3852900583d1258574ff2d7d719abf4513836"},
-    {file = "fonttools-4.43.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:52e77f23a9c059f8be01a07300ba4c4d23dc271d33eed502aea5a01ab5d2f4c1"},
-    {file = "fonttools-4.43.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6a530fa28c155538d32214eafa0964989098a662bd63e91e790e6a7a4e9c02da"},
-    {file = "fonttools-4.43.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70f021a6b9eb10dfe7a411b78e63a503a06955dd6d2a4e130906d8760474f77c"},
-    {file = "fonttools-4.43.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:812142a0e53cc853964d487e6b40963df62f522b1b571e19d1ff8467d7880ceb"},
-    {file = "fonttools-4.43.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ace51902ab67ef5fe225e8b361039e996db153e467e24a28d35f74849b37b7ce"},
-    {file = "fonttools-4.43.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8dfd8edfce34ad135bd69de20c77449c06e2c92b38f2a8358d0987737f82b49e"},
-    {file = "fonttools-4.43.0-cp39-cp39-win32.whl", hash = "sha256:e5d53eddaf436fa131042f44a76ea1ead0a17c354ab9de0d80e818f0cb1629f1"},
-    {file = "fonttools-4.43.0-cp39-cp39-win_amd64.whl", hash = "sha256:93c5b6d77baf28f306bc13fa987b0b13edca6a39dc2324eaca299a74ccc6316f"},
-    {file = "fonttools-4.43.0-py3-none-any.whl", hash = "sha256:e4bc589d8da09267c7c4ceaaaa4fc01a7908ac5b43b286ac9279afe76407c384"},
-    {file = "fonttools-4.43.0.tar.gz", hash = "sha256:b62a53a4ca83c32c6b78cac64464f88d02929779373c716f738af6968c8c821e"},
+    {file = "fonttools-4.43.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bf11e2cca121df35e295bd34b309046c29476ee739753bc6bc9d5050de319273"},
+    {file = "fonttools-4.43.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:10b3922875ffcba636674f406f9ab9a559564fdbaa253d66222019d569db869c"},
+    {file = "fonttools-4.43.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f727c3e3d08fd25352ed76cc3cb61486f8ed3f46109edf39e5a60fc9fecf6ca"},
+    {file = "fonttools-4.43.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad0b3f6342cfa14be996971ea2b28b125ad681c6277c4cd0fbdb50340220dfb6"},
+    {file = "fonttools-4.43.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3b7ad05b2beeebafb86aa01982e9768d61c2232f16470f9d0d8e385798e37184"},
+    {file = "fonttools-4.43.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4c54466f642d2116686268c3e5f35ebb10e49b0d48d41a847f0e171c785f7ac7"},
+    {file = "fonttools-4.43.1-cp310-cp310-win32.whl", hash = "sha256:1e09da7e8519e336239fbd375156488a4c4945f11c4c5792ee086dd84f784d02"},
+    {file = "fonttools-4.43.1-cp310-cp310-win_amd64.whl", hash = "sha256:1cf9e974f63b1080b1d2686180fc1fbfd3bfcfa3e1128695b5de337eb9075cef"},
+    {file = "fonttools-4.43.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5db46659cfe4e321158de74c6f71617e65dc92e54980086823a207f1c1c0e24b"},
+    {file = "fonttools-4.43.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1952c89a45caceedf2ab2506d9a95756e12b235c7182a7a0fff4f5e52227204f"},
+    {file = "fonttools-4.43.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c36da88422e0270fbc7fd959dc9749d31a958506c1d000e16703c2fce43e3d0"},
+    {file = "fonttools-4.43.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bbbf8174501285049e64d174e29f9578495e1b3b16c07c31910d55ad57683d8"},
+    {file = "fonttools-4.43.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d4071bd1c183b8d0b368cc9ed3c07a0f6eb1bdfc4941c4c024c49a35429ac7cd"},
+    {file = "fonttools-4.43.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d21099b411e2006d3c3e1f9aaf339e12037dbf7bf9337faf0e93ec915991f43b"},
+    {file = "fonttools-4.43.1-cp311-cp311-win32.whl", hash = "sha256:b84a1c00f832feb9d0585ca8432fba104c819e42ff685fcce83537e2e7e91204"},
+    {file = "fonttools-4.43.1-cp311-cp311-win_amd64.whl", hash = "sha256:9a2f0aa6ca7c9bc1058a9d0b35483d4216e0c1bbe3962bc62ce112749954c7b8"},
+    {file = "fonttools-4.43.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:4d9740e3783c748521e77d3c397dc0662062c88fd93600a3c2087d3d627cd5e5"},
+    {file = "fonttools-4.43.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:884ef38a5a2fd47b0c1291647b15f4e88b9de5338ffa24ee52c77d52b4dfd09c"},
+    {file = "fonttools-4.43.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9648518ef687ba818db3fcc5d9aae27a369253ac09a81ed25c3867e8657a0680"},
+    {file = "fonttools-4.43.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95e974d70238fc2be5f444fa91f6347191d0e914d5d8ae002c9aa189572cc215"},
+    {file = "fonttools-4.43.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:34f713dad41aa21c637b4e04fe507c36b986a40f7179dcc86402237e2d39dcd3"},
+    {file = "fonttools-4.43.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:360201d46165fc0753229afe785900bc9596ee6974833124f4e5e9f98d0f592b"},
+    {file = "fonttools-4.43.1-cp312-cp312-win32.whl", hash = "sha256:bb6d2f8ef81ea076877d76acfb6f9534a9c5f31dc94ba70ad001267ac3a8e56f"},
+    {file = "fonttools-4.43.1-cp312-cp312-win_amd64.whl", hash = "sha256:25d3da8a01442cbc1106490eddb6d31d7dffb38c1edbfabbcc8db371b3386d72"},
+    {file = "fonttools-4.43.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:8da417431bfc9885a505e86ba706f03f598c85f5a9c54f67d63e84b9948ce590"},
+    {file = "fonttools-4.43.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:51669b60ee2a4ad6c7fc17539a43ffffc8ef69fd5dbed186a38a79c0ac1f5db7"},
+    {file = "fonttools-4.43.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:748015d6f28f704e7d95cd3c808b483c5fb87fd3eefe172a9da54746ad56bfb6"},
+    {file = "fonttools-4.43.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7a58eb5e736d7cf198eee94844b81c9573102ae5989ebcaa1d1a37acd04b33d"},
+    {file = "fonttools-4.43.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6bb5ea9076e0e39defa2c325fc086593ae582088e91c0746bee7a5a197be3da0"},
+    {file = "fonttools-4.43.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5f37e31291bf99a63328668bb83b0669f2688f329c4c0d80643acee6e63cd933"},
+    {file = "fonttools-4.43.1-cp38-cp38-win32.whl", hash = "sha256:9c60ecfa62839f7184f741d0509b5c039d391c3aff71dc5bc57b87cc305cff3b"},
+    {file = "fonttools-4.43.1-cp38-cp38-win_amd64.whl", hash = "sha256:fe9b1ec799b6086460a7480e0f55c447b1aca0a4eecc53e444f639e967348896"},
+    {file = "fonttools-4.43.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:13a9a185259ed144def3682f74fdcf6596f2294e56fe62dfd2be736674500dba"},
+    {file = "fonttools-4.43.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b2adca1b46d69dce4a37eecc096fe01a65d81a2f5c13b25ad54d5430ae430b13"},
+    {file = "fonttools-4.43.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18eefac1b247049a3a44bcd6e8c8fd8b97f3cad6f728173b5d81dced12d6c477"},
+    {file = "fonttools-4.43.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2062542a7565091cea4cc14dd99feff473268b5b8afdee564f7067dd9fff5860"},
+    {file = "fonttools-4.43.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:18a2477c62a728f4d6e88c45ee9ee0229405e7267d7d79ce1f5ce0f3e9f8ab86"},
+    {file = "fonttools-4.43.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a7a06f8d95b7496e53af80d974d63516ffb263a468e614978f3899a6df52d4b3"},
+    {file = "fonttools-4.43.1-cp39-cp39-win32.whl", hash = "sha256:10003ebd81fec0192c889e63a9c8c63f88c7d72ae0460b7ba0cd2a1db246e5ad"},
+    {file = "fonttools-4.43.1-cp39-cp39-win_amd64.whl", hash = "sha256:e117a92b07407a061cde48158c03587ab97e74e7d73cb65e6aadb17af191162a"},
+    {file = "fonttools-4.43.1-py3-none-any.whl", hash = "sha256:4f88cae635bfe4bbbdc29d479a297bb525a94889184bb69fa9560c2d4834ddb9"},
+    {file = "fonttools-4.43.1.tar.gz", hash = "sha256:17dbc2eeafb38d5d0e865dcce16e313c58265a6d2d20081c435f84dc5a9d8212"},
 ]
 
 [package.extras]
@@ -737,45 +708,6 @@ files = [
 numpy = ">=1.17.3"
 
 [[package]]
-name = "holoviews"
-version = "1.17.1"
-description = "Stop plotting your data - annotate your data and let it visualize itself."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "holoviews-1.17.1-py2.py3-none-any.whl", hash = "sha256:cdbb1ea362fd5dd1907c69b939c4d6a63d5225cdc4dd707a4d38d1544be6b11f"},
-    {file = "holoviews-1.17.1.tar.gz", hash = "sha256:ca30c661508b22e9e8c119dbc3e4a5d851987b43c30565db180b291d8fd770a4"},
-]
-
-[package.dependencies]
-colorcet = "*"
-numpy = ">=1.0"
-packaging = "*"
-pandas = ">=0.20.0"
-panel = ">=0.13.1"
-param = ">=1.12.0,<3.0"
-pyviz-comms = ">=0.7.4"
-
-[package.extras]
-all = ["bokeh", "bokeh (>2.2)", "bokeh (>=2.4.3)", "cftime", "codecov", "cudf", "dash (>=1.16)", "dask", "datashader (>=0.11.1)", "ffmpeg", "flaky", "graphviz", "ibis-framework", "ipython (>=5.4.0)", "matplotlib (>=3)", "mpl-sample-data (>=3.1.3)", "nbconvert", "nbsite (>=0.8.2,<0.9.0)", "nbval", "netcdf4", "networkx", "notebook", "pillow", "playwright", "plotly (>=4.0)", "pooch", "pre-commit", "pscript", "pscript (==0.7.1)", "pyarrow", "pytest", "pytest-cov", "pytest-playwright", "pytest-xdist", "ruff", "scikit-image", "scipy", "selenium", "shapely", "spatialpandas", "streamz (>=0.5.0)", "xarray (>=0.10.4)"]
-bokeh2 = ["panel (==0.14.4)", "param (==1.13.0)"]
-bokeh3 = ["panel (>=1.0.0)"]
-build = ["param (>=1.7.0)", "pyct (>=0.4.4)", "setuptools (>=30.3.0)"]
-doc = ["bokeh (>2.2)", "bokeh (>=2.4.3)", "cftime", "dash (>=1.16)", "dask", "datashader (>=0.11.1)", "ffmpeg", "graphviz", "ipython (>=5.4.0)", "matplotlib (>=3)", "mpl-sample-data (>=3.1.3)", "nbsite (>=0.8.2,<0.9.0)", "netcdf4", "networkx", "notebook", "pillow", "plotly (>=4.0)", "pooch", "pscript", "pyarrow", "scikit-image", "scipy", "selenium", "shapely", "streamz (>=0.5.0)", "xarray (>=0.10.4)"]
-examples = ["bokeh (>=2.4.3)", "cftime", "dash (>=1.16)", "dask", "datashader (>=0.11.1)", "ffmpeg", "ipython (>=5.4.0)", "matplotlib (>=3)", "netcdf4", "networkx", "notebook", "pillow", "plotly (>=4.0)", "pooch", "pyarrow", "scikit-image", "scipy", "shapely", "streamz (>=0.5.0)", "xarray (>=0.10.4)"]
-examples-tests = ["bokeh (>=2.4.3)", "cftime", "dash (>=1.16)", "dask", "datashader (>=0.11.1)", "ffmpeg", "ipython (>=5.4.0)", "matplotlib (>=3)", "nbval", "netcdf4", "networkx", "notebook", "pillow", "plotly (>=4.0)", "pooch", "pyarrow", "scikit-image", "scipy", "shapely", "streamz (>=0.5.0)", "xarray (>=0.10.4)"]
-extras = ["bokeh (>=2.4.3)", "cftime", "dash (>=1.16)", "dask", "datashader (>=0.11.1)", "ffmpeg", "ipython (>=5.4.0)", "matplotlib (>=3)", "netcdf4", "networkx", "notebook", "pillow", "plotly (>=4.0)", "pooch", "pscript (==0.7.1)", "pyarrow", "scikit-image", "scipy", "shapely", "streamz (>=0.5.0)", "xarray (>=0.10.4)"]
-lint = ["pre-commit", "ruff"]
-notebook = ["ipython (>=5.4.0)", "notebook"]
-recommended = ["bokeh (>=2.4.3)", "ipython (>=5.4.0)", "matplotlib (>=3)", "notebook"]
-tests = ["bokeh", "cftime", "codecov", "dash (>=1.16)", "dask", "datashader (>=0.11.1)", "ffmpeg", "flaky", "ibis-framework", "ipython (>=5.4.0)", "matplotlib (>=3)", "nbconvert", "networkx", "pillow", "plotly (>=4.0)", "pytest", "pytest-cov", "pytest-xdist", "scipy", "selenium", "shapely", "spatialpandas", "xarray (>=0.10.4)"]
-tests-core = ["bokeh", "codecov", "dash (>=1.16)", "flaky", "ipython (>=5.4.0)", "matplotlib (>=3)", "nbconvert", "pillow", "plotly (>=4.0)", "pytest", "pytest-cov", "pytest-xdist"]
-tests-gpu = ["bokeh", "cftime", "codecov", "cudf", "dash (>=1.16)", "dask", "datashader (>=0.11.1)", "ffmpeg", "flaky", "ibis-framework", "ipython (>=5.4.0)", "matplotlib (>=3)", "nbconvert", "networkx", "pillow", "plotly (>=4.0)", "pytest", "pytest-cov", "pytest-xdist", "scipy", "selenium", "shapely", "spatialpandas", "xarray (>=0.10.4)"]
-tests-nb = ["nbval"]
-ui = ["playwright", "pytest-playwright"]
-unit-tests = ["bokeh", "bokeh (>=2.4.3)", "cftime", "codecov", "dash (>=1.16)", "dask", "datashader (>=0.11.1)", "ffmpeg", "flaky", "ibis-framework", "ipython (>=5.4.0)", "matplotlib (>=3)", "nbconvert", "netcdf4", "networkx", "notebook", "pillow", "plotly (>=4.0)", "pooch", "pre-commit", "pyarrow", "pytest", "pytest-cov", "pytest-xdist", "ruff", "scikit-image", "scipy", "selenium", "shapely", "spatialpandas", "streamz (>=0.5.0)", "xarray (>=0.10.4)"]
-
-[[package]]
 name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -785,37 +717,6 @@ files = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
     {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
 ]
-
-[[package]]
-name = "imageio"
-version = "2.31.5"
-description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "imageio-2.31.5-py3-none-any.whl", hash = "sha256:97f68e12ba676f2f4b541684ed81f7f3370dc347e8321bc68ee34d37b2dbac9f"},
-    {file = "imageio-2.31.5.tar.gz", hash = "sha256:d8e53f9cd4054880276a3dac0a28c85ba7874084856a55a0294a8ae6ed7f3a8e"},
-]
-
-[package.dependencies]
-numpy = "*"
-pillow = ">=8.3.2"
-
-[package.extras]
-all-plugins = ["astropy", "av", "imageio-ffmpeg", "psutil", "tifffile"]
-all-plugins-pypy = ["av", "imageio-ffmpeg", "psutil", "tifffile"]
-build = ["wheel"]
-dev = ["black", "flake8", "fsspec[github]", "pytest", "pytest-cov"]
-docs = ["numpydoc", "pydata-sphinx-theme", "sphinx (<6)"]
-ffmpeg = ["imageio-ffmpeg", "psutil"]
-fits = ["astropy"]
-full = ["astropy", "av", "black", "flake8", "fsspec[github]", "gdal", "imageio-ffmpeg", "itk", "numpydoc", "psutil", "pydata-sphinx-theme", "pytest", "pytest-cov", "sphinx (<6)", "tifffile", "wheel"]
-gdal = ["gdal"]
-itk = ["itk"]
-linting = ["black", "flake8"]
-pyav = ["av"]
-test = ["fsspec[github]", "pytest", "pytest-cov"]
-tifffile = ["tifffile"]
 
 [[package]]
 name = "importlib-metadata"
@@ -989,41 +890,6 @@ files = [
 ]
 
 [[package]]
-name = "lazy-loader"
-version = "0.3"
-description = "lazy_loader"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "lazy_loader-0.3-py3-none-any.whl", hash = "sha256:1e9e76ee8631e264c62ce10006718e80b2cfc74340d17d1031e0f84af7478554"},
-    {file = "lazy_loader-0.3.tar.gz", hash = "sha256:3b68898e34f5b2a29daaaac172c6555512d0f32074f147e2254e4a6d9d838f37"},
-]
-
-[package.extras]
-lint = ["pre-commit (>=3.3)"]
-test = ["pytest (>=7.4)", "pytest-cov (>=4.1)"]
-
-[[package]]
-name = "linkify-it-py"
-version = "2.0.2"
-description = "Links recognition library with FULL unicode support."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "linkify-it-py-2.0.2.tar.gz", hash = "sha256:19f3060727842c254c808e99d465c80c49d2c7306788140987a1a7a29b0d6ad2"},
-    {file = "linkify_it_py-2.0.2-py3-none-any.whl", hash = "sha256:a3a24428f6c96f27370d7fe61d2ac0be09017be5190d68d8658233171f1b6541"},
-]
-
-[package.dependencies]
-uc-micro-py = "*"
-
-[package.extras]
-benchmark = ["pytest", "pytest-benchmark"]
-dev = ["black", "flake8", "isort", "pre-commit", "pyproject-flake8"]
-doc = ["myst-parser", "sphinx", "sphinx-book-theme"]
-test = ["coverage", "pytest", "pytest-cov"]
-
-[[package]]
 name = "lit"
 version = "17.0.2"
 description = "A Software Testing Tool"
@@ -1076,45 +942,6 @@ files = [
     {file = "locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3"},
     {file = "locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632"},
 ]
-
-[[package]]
-name = "markdown"
-version = "3.4.4"
-description = "Python implementation of John Gruber's Markdown."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "Markdown-3.4.4-py3-none-any.whl", hash = "sha256:a4c1b65c0957b4bd9e7d86ddc7b3c9868fb9670660f6f99f6d1bca8954d5a941"},
-    {file = "Markdown-3.4.4.tar.gz", hash = "sha256:225c6123522495d4119a90b3a3ba31a1e87a70369e03f14799ea9c0d7183a3d6"},
-]
-
-[package.extras]
-docs = ["mdx-gh-links (>=0.2)", "mkdocs (>=1.0)", "mkdocs-nature (>=0.4)"]
-testing = ["coverage", "pyyaml"]
-
-[[package]]
-name = "markdown-it-py"
-version = "3.0.0"
-description = "Python port of markdown-it. Markdown parsing, done right!"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
-    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
-]
-
-[package.dependencies]
-mdurl = ">=0.1,<1.0"
-
-[package.extras]
-benchmarking = ["psutil", "pytest", "pytest-benchmark"]
-code-style = ["pre-commit (>=3.0,<4.0)"]
-compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
-linkify = ["linkify-it-py (>=1,<3)"]
-plugins = ["mdit-py-plugins"]
-profiling = ["gprof2dot"]
-rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
-testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
 name = "markupsafe"
@@ -1223,36 +1050,6 @@ pillow = ">=6.2.0"
 pyparsing = ">=2.3.1"
 python-dateutil = ">=2.7"
 setuptools_scm = ">=7"
-
-[[package]]
-name = "mdit-py-plugins"
-version = "0.4.0"
-description = "Collection of plugins for markdown-it-py"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "mdit_py_plugins-0.4.0-py3-none-any.whl", hash = "sha256:b51b3bb70691f57f974e257e367107857a93b36f322a9e6d44ca5bf28ec2def9"},
-    {file = "mdit_py_plugins-0.4.0.tar.gz", hash = "sha256:d8ab27e9aed6c38aa716819fedfde15ca275715955f8a185a8e1cf90fb1d2c1b"},
-]
-
-[package.dependencies]
-markdown-it-py = ">=1.0.0,<4.0.0"
-
-[package.extras]
-code-style = ["pre-commit"]
-rtd = ["myst-parser", "sphinx-book-theme"]
-testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-description = "Markdown URL utilities"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
-    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
-]
 
 [[package]]
 name = "mpmath"
@@ -1637,6 +1434,23 @@ files = [
 ]
 
 [[package]]
+name = "pacmap"
+version = "0.7.1"
+description = "The official implementation for PaCMAP: Pairwise Controlled Manifold Approximation Projection"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pacmap-0.7.1-py3-none-any.whl", hash = "sha256:a14fd68108b4a9f51454e6b190349d5f585de23985c9db82e6526dd549f1152c"},
+    {file = "pacmap-0.7.1.tar.gz", hash = "sha256:fad1ce6cc5ecaccfdbdd16522692a5b45f2f3d7af32fc77c47571b435012ad1d"},
+]
+
+[package.dependencies]
+annoy = ">=1.11"
+numba = ">=0.57"
+numpy = ">=1.20"
+scikit-learn = ">=0.20"
+
+[[package]]
 name = "pandas"
 version = "2.0.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
@@ -1701,42 +1515,6 @@ spss = ["pyreadstat (>=1.1.2)"]
 sql-other = ["SQLAlchemy (>=1.4.16)"]
 test = ["hypothesis (>=6.34.2)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.6.3)"]
-
-[[package]]
-name = "panel"
-version = "1.2.3"
-description = "The powerful data exploration & web app framework for Python."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "panel-1.2.3-py2.py3-none-any.whl", hash = "sha256:0805bacf4a613e8869163bf80f50e59a89838afe76bdbe6a05ab5637f32683f7"},
-    {file = "panel-1.2.3.tar.gz", hash = "sha256:5a9160fe084f918cb0900b6a4ef62d3ce542fcd2b8907d0b94113f13a8eea2d3"},
-]
-
-[package.dependencies]
-bleach = "*"
-bokeh = ">=3.1.1,<3.3.0"
-linkify-it-py = "*"
-markdown = "*"
-markdown-it-py = "*"
-mdit-py-plugins = "*"
-pandas = ">=1.2"
-param = ">=1.12.0"
-pyviz-comms = ">=0.7.4"
-requests = "*"
-tqdm = ">=4.48.0"
-typing-extensions = "*"
-xyzservices = ">=2021.09.1"
-
-[package.extras]
-all = ["aiohttp", "altair", "anywidget", "channels", "croniter", "datashader", "diskcache", "django (<4)", "fastparquet", "flake8", "flaky", "folium", "graphviz", "holoviews (>=1.16.0)", "hvplot", "ipyleaflet", "ipympl", "ipython (>=7.0)", "ipyvolume", "ipyvuetify", "ipywidgets", "ipywidgets-bokeh", "jupyter-bokeh (>=3.0.7)", "jupyter-server", "jupyterlab", "lxml", "matplotlib", "nbsite (==0.8.2)", "nbval", "networkx (>=2.5)", "numpy", "pandas (<2.1.0)", "pandas (>=1.3)", "parameterized", "pillow", "playwright", "plotly", "plotly (>=4.0)", "pre-commit", "psutil", "pydeck", "pygraphviz", "pyinstrument (>=4.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-playwright", "pytest-xdist", "python-graphviz", "pyvista", "reacton", "scikit-image", "scikit-learn", "scipy", "seaborn", "streamz", "twine", "vega-datasets", "vtk", "xarray", "xgboost"]
-all-pip = ["aiohttp", "altair", "anywidget", "channels", "croniter", "datashader", "diskcache", "django (<4)", "fastparquet", "flake8", "flaky", "folium", "graphviz", "holoviews (>=1.16.0)", "hvplot", "ipyleaflet", "ipympl", "ipython (>=7.0)", "ipyvolume", "ipyvuetify", "ipywidgets", "ipywidgets-bokeh", "jupyter-bokeh (>=3.0.7)", "jupyter-server", "jupyterlab", "lxml", "matplotlib", "nbsite (==0.8.2)", "nbval", "networkx (>=2.5)", "numpy", "pandas (<2.1.0)", "pandas (>=1.3)", "parameterized", "pillow", "playwright", "plotly", "plotly (>=4.0)", "pre-commit", "psutil", "pydeck", "pyinstrument (>=4.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-playwright", "pytest-xdist", "pyvista", "reacton", "scikit-image", "scikit-learn", "scipy", "seaborn", "streamz", "twine", "vega-datasets", "vtk", "xarray", "xgboost"]
-build = ["bleach", "bokeh (>=3.1.1,<3.3.0)", "cryptography (<39)", "packaging", "param (>=1.9.2)", "pyviz-comms (>=0.7.4)", "requests", "setuptools (>=42)", "tqdm (>=4.48.0)", "urllib3 (<2.0)"]
-doc = ["holoviews (>=1.16.0)", "jupyterlab", "lxml", "matplotlib", "nbsite (==0.8.2)", "pandas (<2.1.0)", "pillow", "plotly"]
-examples = ["aiohttp", "altair", "channels", "croniter", "datashader", "django (<4)", "fastparquet", "folium", "graphviz", "holoviews (>=1.16.0)", "hvplot", "ipyleaflet", "ipympl", "ipyvolume", "ipyvuetify", "ipywidgets", "ipywidgets-bokeh", "jupyter-bokeh (>=3.0.7)", "networkx (>=2.5)", "plotly (>=4.0)", "pydeck", "pygraphviz", "pyinstrument (>=4.0)", "python-graphviz", "pyvista", "reacton", "scikit-image", "scikit-learn", "seaborn", "streamz", "vega-datasets", "vtk", "xarray", "xgboost"]
-recommended = ["holoviews (>=1.16.0)", "jupyterlab", "matplotlib", "pillow", "plotly"]
-tests = ["altair", "anywidget", "diskcache", "flake8", "flaky", "folium", "holoviews (>=1.16.0)", "ipympl", "ipython (>=7.0)", "ipyvuetify", "ipywidgets-bokeh", "nbval", "numpy", "pandas (>=1.3)", "parameterized", "pre-commit", "psutil", "pytest", "pytest-asyncio", "pytest-cov", "pytest-xdist", "reacton", "scipy", "twine"]
-ui = ["jupyter-server", "playwright", "pytest-playwright"]
 
 [[package]]
 name = "parafac2"
@@ -2009,25 +1787,6 @@ files = [
 ]
 
 [[package]]
-name = "pyviz-comms"
-version = "3.0.0"
-description = "A JupyterLab extension for rendering HoloViz content."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pyviz_comms-3.0.0-py3-none-any.whl", hash = "sha256:91c967151b1e4d436c458c147a31991a42fbe7567e49176e4eb5b8dc8e20f1ff"},
-    {file = "pyviz_comms-3.0.0.tar.gz", hash = "sha256:f4ca91e4157a64e3abed7cc249e60b9a8d2532f8832f1cb075914d19337d2ba6"},
-]
-
-[package.dependencies]
-param = "*"
-
-[package.extras]
-all = ["pyviz-comms[build]", "pyviz-comms[tests]"]
-build = ["jupyterlab (>=4.0,<5.0)", "keyring", "rfc3986", "setuptools (>=40.8.0)", "twine"]
-tests = ["flake8", "pytest"]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -2145,54 +1904,6 @@ skmisc = ["scikit-misc (>=0.1.3)"]
 test = ["scanpy[dask]", "scanpy[leiden]", "scanpy[test-min]", "zarr"]
 test-full = ["scanpy[harmony]", "scanpy[leiden]", "scanpy[magic]", "scanpy[scanorama]", "scanpy[scrublet]", "scanpy[skmisc]", "scanpy[test]"]
 test-min = ["profimp", "pytest (>=4.4)", "pytest-nunit"]
-
-[[package]]
-name = "scikit-image"
-version = "0.22.0"
-description = "Image processing in Python"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "scikit_image-0.22.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:74ec5c1d4693506842cc7c9487c89d8fc32aed064e9363def7af08b8f8cbb31d"},
-    {file = "scikit_image-0.22.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:a05ae4fe03d802587ed8974e900b943275548cde6a6807b785039d63e9a7a5ff"},
-    {file = "scikit_image-0.22.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a92dca3d95b1301442af055e196a54b5a5128c6768b79fc0a4098f1d662dee6"},
-    {file = "scikit_image-0.22.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3663d063d8bf2fb9bdfb0ca967b9ee3b6593139c860c7abc2d2351a8a8863938"},
-    {file = "scikit_image-0.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:ebdbdc901bae14dab637f8d5c99f6d5cc7aaf4a3b6f4003194e003e9f688a6fc"},
-    {file = "scikit_image-0.22.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:95d6da2d8a44a36ae04437c76d32deb4e3c993ffc846b394b9949fd8ded73cb2"},
-    {file = "scikit_image-0.22.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:2c6ef454a85f569659b813ac2a93948022b0298516b757c9c6c904132be327e2"},
-    {file = "scikit_image-0.22.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e87872f067444ee90a00dd49ca897208308645382e8a24bd3e76f301af2352cd"},
-    {file = "scikit_image-0.22.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5c378db54e61b491b9edeefff87e49fcf7fdf729bb93c777d7a5f15d36f743e"},
-    {file = "scikit_image-0.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:2bcb74adb0634258a67f66c2bb29978c9a3e222463e003b67ba12056c003971b"},
-    {file = "scikit_image-0.22.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:003ca2274ac0fac252280e7179ff986ff783407001459ddea443fe7916e38cff"},
-    {file = "scikit_image-0.22.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:cf3c0c15b60ae3e557a0c7575fbd352f0c3ce0afca562febfe3ab80efbeec0e9"},
-    {file = "scikit_image-0.22.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5b23908dd4d120e6aecb1ed0277563e8cbc8d6c0565bdc4c4c6475d53608452"},
-    {file = "scikit_image-0.22.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be79d7493f320a964f8fcf603121595ba82f84720de999db0fcca002266a549a"},
-    {file = "scikit_image-0.22.0-cp312-cp312-win_amd64.whl", hash = "sha256:722b970aa5da725dca55252c373b18bbea7858c1cdb406e19f9b01a4a73b30b2"},
-    {file = "scikit_image-0.22.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:22318b35044cfeeb63ee60c56fc62450e5fe516228138f1d06c7a26378248a86"},
-    {file = "scikit_image-0.22.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:9e801c44a814afdadeabf4dffdffc23733e393767958b82319706f5fa3e1eaa9"},
-    {file = "scikit_image-0.22.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c472a1fb3665ec5c00423684590631d95f9afcbc97f01407d348b821880b2cb3"},
-    {file = "scikit_image-0.22.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b7a6c89e8d6252332121b58f50e1625c35f7d6a85489c0b6b7ee4f5155d547a"},
-    {file = "scikit_image-0.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:5071b8f6341bfb0737ab05c8ab4ac0261f9e25dbcc7b5d31e5ed230fd24a7929"},
-    {file = "scikit_image-0.22.0.tar.gz", hash = "sha256:018d734df1d2da2719087d15f679d19285fce97cd37695103deadfaef2873236"},
-]
-
-[package.dependencies]
-imageio = ">=2.27"
-lazy_loader = ">=0.3"
-networkx = ">=2.8"
-numpy = ">=1.22"
-packaging = ">=21"
-pillow = ">=9.0.1"
-scipy = ">=1.8"
-tifffile = ">=2022.8.12"
-
-[package.extras]
-build = ["Cython (>=0.29.32)", "build", "meson-python (>=0.14)", "ninja", "numpy (>=1.22)", "packaging (>=21)", "pythran", "setuptools (>=67)", "spin (==0.6)", "wheel"]
-data = ["pooch (>=1.6.0)"]
-developer = ["pre-commit", "tomli"]
-docs = ["PyWavelets (>=1.1.1)", "dask[array] (>=2022.9.2)", "ipykernel", "ipywidgets", "kaleido", "matplotlib (>=3.5)", "myst-parser", "numpydoc (>=1.6)", "pandas (>=1.5)", "plotly (>=5.10)", "pooch (>=1.6)", "pydata-sphinx-theme (>=0.14.1)", "pytest-runner", "scikit-learn (>=1.1)", "seaborn (>=0.11)", "sphinx (>=7.2)", "sphinx-copybutton", "sphinx-gallery (>=0.14)", "sphinx_design (>=0.5)", "tifffile (>=2022.8.12)"]
-optional = ["PyWavelets (>=1.1.1)", "SimpleITK", "astropy (>=5.0)", "cloudpickle (>=0.2.1)", "dask[array] (>=2021.1.0)", "matplotlib (>=3.5)", "pooch (>=1.6.0)", "pyamg", "scikit-learn (>=1.1)"]
-test = ["asv", "matplotlib (>=3.5)", "numpydoc (>=1.5)", "pooch (>=1.6.0)", "pytest (>=7.0)", "pytest-cov (>=2.11.0)", "pytest-faulthandler", "pytest-localserver"]
 
 [[package]]
 name = "scikit-learn"
@@ -2461,23 +2172,6 @@ files = [
 ]
 
 [[package]]
-name = "tifffile"
-version = "2023.9.26"
-description = "Read and write TIFF files"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "tifffile-2023.9.26-py3-none-any.whl", hash = "sha256:1de47fa945fddaade256e25ad4f375ae65547f3c1354063aded881c32a64cf89"},
-    {file = "tifffile-2023.9.26.tar.gz", hash = "sha256:67e355e4595aab397f8405d04afe1b4ae7c6f62a44e22d933fee1a571a48c7ae"},
-]
-
-[package.dependencies]
-numpy = "*"
-
-[package.extras]
-all = ["defusedxml", "fsspec", "imagecodecs (>=2023.8.12)", "lxml", "matplotlib", "zarr"]
-
-[[package]]
 name = "toolz"
 version = "0.12.0"
 description = "List processing tools and functional utilities"
@@ -2542,26 +2236,6 @@ typing-extensions = "*"
 
 [package.extras]
 opt-einsum = ["opt-einsum (>=3.3)"]
-
-[[package]]
-name = "tornado"
-version = "6.3.3"
-description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
-optional = false
-python-versions = ">= 3.8"
-files = [
-    {file = "tornado-6.3.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:502fba735c84450974fec147340016ad928d29f1e91f49be168c0a4c18181e1d"},
-    {file = "tornado-6.3.3-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:805d507b1f588320c26f7f097108eb4023bbaa984d63176d1652e184ba24270a"},
-    {file = "tornado-6.3.3-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bd19ca6c16882e4d37368e0152f99c099bad93e0950ce55e71daed74045908f"},
-    {file = "tornado-6.3.3-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ac51f42808cca9b3613f51ffe2a965c8525cb1b00b7b2d56828b8045354f76a"},
-    {file = "tornado-6.3.3-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:71a8db65160a3c55d61839b7302a9a400074c9c753040455494e2af74e2501f2"},
-    {file = "tornado-6.3.3-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:ceb917a50cd35882b57600709dd5421a418c29ddc852da8bcdab1f0db33406b0"},
-    {file = "tornado-6.3.3-cp38-abi3-musllinux_1_1_i686.whl", hash = "sha256:7d01abc57ea0dbb51ddfed477dfe22719d376119844e33c661d873bf9c0e4a16"},
-    {file = "tornado-6.3.3-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:9dc4444c0defcd3929d5c1eb5706cbe1b116e762ff3e0deca8b715d14bf6ec17"},
-    {file = "tornado-6.3.3-cp38-abi3-win32.whl", hash = "sha256:65ceca9500383fbdf33a98c0087cb975b2ef3bfb874cb35b8de8740cf7f41bd3"},
-    {file = "tornado-6.3.3-cp38-abi3-win_amd64.whl", hash = "sha256:22d3c2fa10b5793da13c807e6fc38ff49a4f6e1e3868b0a6f4164768bb8e20f5"},
-    {file = "tornado-6.3.3.tar.gz", hash = "sha256:e7d8db41c0181c80d76c982aacc442c0783a2c54d6400fe028954201a2e032fe"},
-]
 
 [[package]]
 name = "tqdm"
@@ -2643,20 +2317,6 @@ files = [
 ]
 
 [[package]]
-name = "uc-micro-py"
-version = "1.0.2"
-description = "Micro subset of unicode data files for linkify-it-py projects."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "uc-micro-py-1.0.2.tar.gz", hash = "sha256:30ae2ac9c49f39ac6dce743bd187fcd2b574b16ca095fa74cd9396795c954c54"},
-    {file = "uc_micro_py-1.0.2-py3-none-any.whl", hash = "sha256:8c9110c309db9d9e87302e2f4ad2c3152770930d88ab385cd544e7a7e75f3de0"},
-]
-
-[package.extras]
-test = ["coverage", "pytest", "pytest-cov"]
-
-[[package]]
 name = "umap-learn"
 version = "0.5.4"
 description = "Uniform Manifold Approximation and Projection"
@@ -2667,19 +2327,11 @@ files = [
 ]
 
 [package.dependencies]
-bokeh = {version = "*", optional = true, markers = "extra == \"plot\""}
-colorcet = {version = "*", optional = true, markers = "extra == \"plot\""}
-datashader = {version = "*", optional = true, markers = "extra == \"plot\""}
-holoviews = {version = "*", optional = true, markers = "extra == \"plot\""}
-matplotlib = {version = "*", optional = true, markers = "extra == \"plot\""}
 numba = ">=0.51.2"
 numpy = ">=1.17"
-pandas = {version = "*", optional = true, markers = "extra == \"plot\""}
 pynndescent = ">=0.5"
-scikit-image = {version = "*", optional = true, markers = "extra == \"plot\""}
 scikit-learn = ">=0.22"
 scipy = ">=1.3.1"
-seaborn = {version = "*", optional = true, markers = "extra == \"plot\""}
 tqdm = "*"
 
 [package.extras]
@@ -2702,17 +2354,6 @@ brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
 secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
-
-[[package]]
-name = "webencodings"
-version = "0.5.1"
-description = "Character encoding aliases for legacy web content"
-optional = false
-python-versions = "*"
-files = [
-    {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
-    {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
-]
 
 [[package]]
 name = "wheel"
@@ -2752,17 +2393,6 @@ parallel = ["dask[complete]"]
 viz = ["matplotlib", "nc-time-axis", "seaborn"]
 
 [[package]]
-name = "xyzservices"
-version = "2023.7.0"
-description = "Source of XYZ tiles providers"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "xyzservices-2023.7.0-py3-none-any.whl", hash = "sha256:88e9cbf22b31a2f9c1b242e2b18690f5c705f0e539c9bfd37a10399e1037731b"},
-    {file = "xyzservices-2023.7.0.tar.gz", hash = "sha256:0ec928742227d6f5d4367ea7b457fcfed943429f4de2949b5b02a82cdf5569d6"},
-]
-
-[[package]]
 name = "zipp"
 version = "3.17.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -2780,4 +2410,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "4ec15299777f20ebef2a0ae77cfdedf9e69cb764eb0edb8bf779dab464c468da"
+content-hash = "6b2a09f1371cbde974f5ce4e1288da2ee769890fdfa78597ffd7a451ad0b7ce4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,12 @@ anndata = "^0.9.2"
 torch = "2.0.0"
 numba = "^0.58.0"
 datashader = "^0.15"
-umap-learn = { version = "^0.5.4", extras = ["plot"] }
 mygene = "^3.2.2"
 gseapy = "^1.0.4"
 openpyxl = "^3.1.2"
 parafac2 = { git = "https://github.com/meyer-lab/parafac2.git", rev = "f05b0ee91a9eb9dfe21d5e7b0fae73802ac62d87" }
 scanpy = "^1.9.5"
+pacmap = "^0.7.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.3"

--- a/sccp/figures/common.py
+++ b/sccp/figures/common.py
@@ -9,7 +9,6 @@ import matplotlib
 from matplotlib.figure import Figure
 from matplotlib import gridspec, pyplot as plt
 import numpy as np
-import pickle
 import pandas as pd
 from .commonFuncs.plotFactors import reorder_table
 from ..parafac2 import Pf2X
@@ -127,22 +126,6 @@ def openPf2(rank: int, dataName: str, optProjs: bool=False):
         
 
     return weight, factors, projs
-
-
-def saveUMAP(fit_points, rank: int, dataName: str):
-    """Saves UMAP points locally, large files uploaded manually to opt"""
-    f_name = f"./sccp/data/{dataName}/{dataName}_UMAPCmp{rank}.sav"
-    pickle.dump(fit_points, open(f_name, "wb"))
-
-
-def openUMAP(rank: int, dataName: str, opt=True):
-    """Opens UMAP points for plotting, defaults to using the opt folder (for big files)"""
-    if opt == True:
-        f_name = f"/opt/andrew/{dataName}/{dataName}_UMAPCmp{rank}.sav"
-    else:
-        f_name = f"./sccp/data/{dataName}/{dataName}_UMAPCmp{rank}.sav"
-
-    return pickle.load((open(f_name, "rb")))
 
 
 def flattenData(data: Pf2X) -> pd.DataFrame:

--- a/sccp/figures/commonFuncs/plotUMAP.py
+++ b/sccp/figures/commonFuncs/plotUMAP.py
@@ -1,13 +1,170 @@
 import seaborn as sns
+import matplotlib.colors
 from matplotlib import pyplot as plt
+from matplotlib.axes import Axes
 import umap
 import numpy as np
 import pandas as pd
-from umap.plot import _get_embedding, _select_font_color, _datashade_points, _get_metric
+import datashader as ds
+import datashader.transfer_functions as tf
+from matplotlib.patches import Patch
+
+
+def _red(x):
+    return (x & 0xFF0000) >> 16
+
+
+def _green(x):
+    return (x & 0x00FF00) >> 8
+
+
+def _blue(x):
+    return x & 0x0000FF
+
+
+def _get_extent(points):
+    """Compute bounds on a space with appropriate padding"""
+    min_x = np.nanmin(points[:, 0])
+    max_x = np.nanmax(points[:, 0])
+    min_y = np.nanmin(points[:, 1])
+    max_y = np.nanmax(points[:, 1])
+
+    extent = (
+        np.round(min_x - 0.05 * (max_x - min_x)),
+        np.round(max_x + 0.05 * (max_x - min_x)),
+        np.round(min_y - 0.05 * (max_y - min_y)),
+        np.round(max_y + 0.05 * (max_y - min_y)),
+    )
+
+    return extent
+
+
+def _to_hex(arr):
+    return [matplotlib.colors.to_hex(c) for c in arr]
+
+
+def _embed_datashader_in_an_axis(datashader_image, ax):
+    img_rev = datashader_image.data[::-1]
+    mpl_img = np.dstack([_blue(img_rev), _green(img_rev), _red(img_rev)])
+    ax.imshow(mpl_img)
+    return ax
+
+
+def _datashade_points(
+    points,
+    ax=None,
+    labels=None,
+    values=None,
+    cmap="Blues",
+    color_key=None,
+    color_key_cmap="Spectral",
+    background="white",
+    width=800,
+    height=800,
+    show_legend=True,
+    alpha=255,
+):
+
+    """Use datashader to plot points"""
+    extent = _get_extent(points)
+    canvas = ds.Canvas(
+        plot_width=width,
+        plot_height=height,
+        x_range=(extent[0], extent[1]),
+        y_range=(extent[2], extent[3]),
+    )
+    data = pd.DataFrame(points, columns=("x", "y"))
+
+    legend_elements = None
+
+    # Color by labels
+    if labels is not None:
+        if labels.shape[0] != points.shape[0]:
+            raise ValueError(
+                "Labels must have a label for "
+                "each sample (size mismatch: {} {})".format(
+                    labels.shape[0], points.shape[0]
+                )
+            )
+
+        data["label"] = pd.Categorical(labels)
+        aggregation = canvas.points(data, "x", "y", agg=ds.count_cat("label"))
+        if color_key is None and color_key_cmap is None:
+            result = tf.shade(aggregation, how="eq_hist", alpha=alpha, min_alpha=255)
+        elif color_key is None:
+            unique_labels = np.unique(labels)
+            num_labels = unique_labels.shape[0]
+            color_key = _to_hex(
+                plt.get_cmap(color_key_cmap)(np.linspace(0, 1, num_labels))
+            )
+            legend_elements = [
+                Patch(facecolor=color_key[i], label=k)
+                for i, k in enumerate(unique_labels)
+            ]
+            result = tf.shade(
+                aggregation, color_key=color_key, how="eq_hist", alpha=alpha, min_alpha=255
+            )
+        else:
+            legend_elements = [
+                Patch(facecolor=color_key[k], label=k) for k in color_key.keys()
+            ]
+            result = tf.shade(
+                aggregation, color_key=color_key, how="eq_hist", alpha=alpha, min_alpha=255
+            )
+
+    # Color by values
+    elif values is not None:
+        if values.shape[0] != points.shape[0]:
+            raise ValueError(
+                "Values must have a value for "
+                "each sample (size mismatch: {} {})".format(
+                    values.shape[0], points.shape[0]
+                )
+            )
+        unique_values = np.unique(values)
+        if unique_values.shape[0] >= 256:
+            min_val, max_val = np.min(values), np.max(values)
+            bin_size = (max_val - min_val) / 255.0
+            data["val_cat"] = pd.Categorical(
+                np.round((values - min_val) / bin_size).astype(np.int16)
+            )
+            aggregation = canvas.points(data, "x", "y", agg=ds.count_cat("val_cat"))
+            color_key = _to_hex(plt.get_cmap(cmap)(np.linspace(0, 1, 256)))
+            result = tf.shade(
+                aggregation, color_key=color_key, how="eq_hist", alpha=alpha, min_alpha=255
+            )
+        else:
+            data["val_cat"] = pd.Categorical(values)
+            aggregation = canvas.points(data, "x", "y", agg=ds.count_cat("val_cat"))
+            color_key_cols = _to_hex(
+                plt.get_cmap(cmap)(np.linspace(0, 1, unique_values.shape[0]))
+            )
+            color_key = dict(zip(unique_values, color_key_cols))
+            result = tf.shade(
+                aggregation, color_key=color_key, how="eq_hist", alpha=alpha, min_alpha=255
+            )
+
+    # Color by density (default datashader option)
+    else:
+        aggregation = canvas.points(data, "x", "y", agg=ds.count())
+        result = tf.shade(aggregation, cmap=plt.get_cmap(cmap), alpha=alpha, how='log')
+
+    if background is not None:
+        result = tf.set_background(result, background)
+
+    if ax is not None:
+        _embed_datashader_in_an_axis(result, ax)
+        if show_legend and legend_elements is not None:
+            ax.legend(handles=legend_elements)
+        return ax
+    else:
+        return result
+
+
 
 
 def points(
-    umap_object: umap.UMAP,
+    umap_object,
     labels=None,
     values=None,
     cmap="Blues",
@@ -29,7 +186,7 @@ def points(
         if not 0.0 <= alpha <= 1.0:
             raise ValueError("Alpha must be between 0 and 1 inclusive")
 
-    points = _get_embedding(umap_object)
+    points = umap_object
 
     if points.shape[1] != 2:
         raise ValueError("Plotting is currently only implemented for 2D embeddings")
@@ -60,52 +217,23 @@ def points(
     )
 
     ax.set(xticks=[], yticks=[])
-    ax.text(
-        0.99,
-        0.01,
-        "UMAP: metric={}, n_neighbors={}, min_dist={}".format(
-            _get_metric(umap_object), umap_object.n_neighbors, umap_object.min_dist
-        ),
-        transform=ax.transAxes,
-        horizontalalignment="right",
-        color=_select_font_color(background),
-    )
 
     return ax
-
-
-def plotCondUMAP(conds, decomp, totalconds, umappoints, axs: list[plt.Axes]):
-    """Scatterplot of UMAP visualization weighted by condition"""
-    for i, cond in enumerate(conds):
-        condList = np.where(np.asarray(totalconds == cond), cond, " Other Conditions")
-        points(
-            umappoints,
-            labels=condList,
-            ax=axs[i],
-            color_key_cmap="tab20",
-            show_legend=True,
-        )
-        axs[i].set(
-            title=decomp + "-Based Decomposition", ylabel="UMAP2", xlabel="UMAP1"
-        )
 
 
 def plotGeneUMAP(
     genes: list[str],
     decomp,
-    umappoints: umap.UMAP,
+    umappoints,
     dataDF: pd.DataFrame,
-    axs: list[plt.Axes]
+    axs: list[Axes]
 ):
     """Scatterplot of UMAP visualization weighted by gene"""
-    cmap = sns.color_palette("ch:s=-.2,r=.6", as_cmap=True)
-
     for i, genez in enumerate(genes):
         geneList = dataDF[genez].to_numpy()
-        geneList = geneList / np.max(np.abs(geneList))
-        psm = plt.pcolormesh([[0, 1], [0, 1]], cmap=cmap)
-        plot = points(umappoints, values=geneList, cmap=cmap, ax=axs[i])
-        colorbar = plt.colorbar(psm, ax=plot)
+        geneList = np.clip(geneList, None, np.quantile(geneList, 0.99))
+        plot = points(umappoints, values=geneList, cmap="winter", ax=axs[i])
+        # colorbar = plt.colorbar(psm, ax=plot)
         axs[i].set(
             title=genez + "-" + decomp + "-Based Decomposition",
             ylabel="UMAP2",
@@ -114,7 +242,7 @@ def plotGeneUMAP(
 
 
 def plotCmpUMAP(
-    cmp: int, factors: np.ndarray, umappoints: umap.UMAP, allP: np.ndarray, ax: plt.Axes
+    cmp: int, factors: np.ndarray, umappoints: umap.UMAP, allP: np.ndarray, ax: Axes
 ):
     """Scatterplot of UMAP visualization weighted by
     projections for a component and cell state"""
@@ -130,7 +258,7 @@ def plotCmpUMAP(
     ax.set(ylabel="UMAP2", xlabel="UMAP1", title="Cmp. " + str(cmp))
 
 
-def plotUMAP_obslabel(labels, umappoints, ax: plt.Axes):
+def plotUMAP_obslabel(labels, umappoints, ax: Axes):
     """Scatterplot of UMAP visualization labeled by cell type or other obs column"""
     points(umappoints, labels=labels, color_key_cmap="Paired", ax=ax)
     ax.set(
@@ -140,19 +268,19 @@ def plotUMAP_obslabel(labels, umappoints, ax: plt.Axes):
     )
 
 
-def plotLabelAllUMAP(conditions, umappoints, ax: plt.Axes):
+def plotLabelAllUMAP(conditions, umappoints, ax: Axes):
     """Scatterplot of UMAP visualization weighted by condition or cell type"""
     points(umappoints, labels=conditions, ax=ax, color_key_cmap="tab20", show_legend=True)
     ax.set(title="Pf2-Based Decomposition", ylabel="UMAP2", xlabel="UMAP1")
 
 
-def plotCellTypeUMAP(umappoints, data, ax: plt.Axes):
+def plotCellTypeUMAP(umappoints, data, ax: Axes):
     """Plots UMAP labeled by cell type"""
     points(umappoints, labels=data["Cell Type"].values, ax=ax)
     ax.set(ylabel="UMAP2", xlabel="UMAP1")
 
 
-def plotCmpPerCellType(weightedprojs, cmp, ax: plt.Axes, outliers=True):
+def plotCmpPerCellType(weightedprojs, cmp, ax: Axes, outliers=True):
     """Boxplot of weighted projections for one component across cell types"""
     cmpName = "Cmp. " + str(cmp)
     sns.boxplot(

--- a/sccp/figures/commonFuncs/plotUMAP.py
+++ b/sccp/figures/commonFuncs/plotUMAP.py
@@ -273,12 +273,6 @@ def plotLabelAllUMAP(conditions, umappoints: np.ndarray, ax: Axes):
     ax.set(title="Pf2-Based Decomposition", ylabel="UMAP2", xlabel="UMAP1")
 
 
-def plotCellTypeUMAP(umappoints: np.ndarray, data, ax: Axes):
-    """Plots UMAP labeled by cell type"""
-    points(umappoints, labels=data["Cell Type"].values, ax=ax)
-    ax.set(ylabel="UMAP2", xlabel="UMAP1")
-
-
 def plotCmpPerCellType(weightedprojs, cmp, ax: Axes, outliers=True):
     """Boxplot of weighted projections for one component across cell types"""
     cmpName = "Cmp. " + str(cmp)

--- a/sccp/figures/commonFuncs/plotUMAP.py
+++ b/sccp/figures/commonFuncs/plotUMAP.py
@@ -2,7 +2,6 @@ import seaborn as sns
 import matplotlib.colors
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
-import umap
 import numpy as np
 import pandas as pd
 import datashader as ds
@@ -242,7 +241,7 @@ def plotGeneUMAP(
 
 
 def plotCmpUMAP(
-    cmp: int, factors: np.ndarray, umappoints: umap.UMAP, allP: np.ndarray, ax: Axes
+    cmp: int, factors: np.ndarray, umappoints: np.ndarray, allP: np.ndarray, ax: Axes
 ):
     """Scatterplot of UMAP visualization weighted by
     projections for a component and cell state"""
@@ -258,7 +257,7 @@ def plotCmpUMAP(
     ax.set(ylabel="UMAP2", xlabel="UMAP1", title="Cmp. " + str(cmp))
 
 
-def plotUMAP_obslabel(labels, umappoints, ax: Axes):
+def plotUMAP_obslabel(labels, umappoints: np.ndarray, ax: Axes):
     """Scatterplot of UMAP visualization labeled by cell type or other obs column"""
     points(umappoints, labels=labels, color_key_cmap="Paired", ax=ax)
     ax.set(
@@ -268,13 +267,13 @@ def plotUMAP_obslabel(labels, umappoints, ax: Axes):
     )
 
 
-def plotLabelAllUMAP(conditions, umappoints, ax: Axes):
+def plotLabelAllUMAP(conditions, umappoints: np.ndarray, ax: Axes):
     """Scatterplot of UMAP visualization weighted by condition or cell type"""
     points(umappoints, labels=conditions, ax=ax, color_key_cmap="tab20", show_legend=True)
     ax.set(title="Pf2-Based Decomposition", ylabel="UMAP2", xlabel="UMAP1")
 
 
-def plotCellTypeUMAP(umappoints, data, ax: Axes):
+def plotCellTypeUMAP(umappoints: np.ndarray, data, ax: Axes):
     """Plots UMAP labeled by cell type"""
     points(umappoints, labels=data["Cell Type"].values, ax=ax)
     ax.set(ylabel="UMAP2", xlabel="UMAP1")

--- a/sccp/figures/figureCITEseq1.py
+++ b/sccp/figures/figureCITEseq1.py
@@ -5,7 +5,7 @@ from .common import subplotLabel, getSetup, openPf2
 from .commonFuncs.plotFactors import (
     plotFactors,
 )
-import umap
+import pacmap
 from ..imports.citeseq import import_citeseq
 from .commonFuncs.plotUMAP import points
 
@@ -25,7 +25,7 @@ def makeFigure():
 
     plotFactors(factors, data, ax[0:3], reorder=(0, 2), trim=(2,))
 
-    pf2Points = umap.UMAP(random_state=1).fit(projs)
+    pf2Points = pacmap.PaCMAP().fit_transform(projs)
 
     points(
         pf2Points,

--- a/sccp/figures/figureCITEseq2.py
+++ b/sccp/figures/figureCITEseq2.py
@@ -2,7 +2,7 @@
 Hamad CITEseq dataset
 """
 import numpy as np
-import umap
+import pacmap
 
 from .common import (
     subplotLabel,
@@ -26,7 +26,7 @@ def makeFigure():
 
     _, factors, projs = openPf2(rank=rank, dataName="CITEseq")
 
-    pf2Points = umap.UMAP(random_state=1).fit(projs)
+    pf2Points = pacmap.PaCMAP().fit_transform(projs)
 
     component = np.arange(1, 25, 1)
 

--- a/sccp/figures/figureCITEseq3.py
+++ b/sccp/figures/figureCITEseq3.py
@@ -2,7 +2,7 @@
 Hamad CITEseq dataset
 """
 import numpy as np
-import umap
+import pacmap
 
 from .common import (
     subplotLabel,
@@ -26,7 +26,7 @@ def makeFigure():
 
     _, _, projs = openPf2(rank=rank, dataName="CITEseq")
 
-    pf2Points = umap.UMAP(random_state=1).fit(projs)
+    pf2Points = pacmap.PaCMAP().fit_transform(projs)
 
     protNames = np.unique(protDF.drop(columns="Condition").columns)
 
@@ -34,7 +34,7 @@ def makeFigure():
     # protNames = protNames[24:48]
     # protNames = protNames[50:75]
     # protNames = protNames[75:100]
-    protNames = protNames[100:]
+    protNames = protNames[100:].tolist()
 
     plotGeneUMAP(protNames, "Pf2", pf2Points, protDF, ax[0:25])
 

--- a/sccp/figures/figureLupus2.py
+++ b/sccp/figures/figureLupus2.py
@@ -5,7 +5,8 @@ data: https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE174188
 """
 
 # GOAL: visualize the cell state compostition by cell type/UMAP
-from .common import subplotLabel, getSetup, openPf2, openUMAP
+import pacmap
+from .common import subplotLabel, getSetup, openPf2
 from .commonFuncs.plotUMAP import plotCmpUMAP, plotUMAP_obslabel
 from ..imports.scRNA import load_lupus_data
 
@@ -37,7 +38,7 @@ def makeFigure():
     ) = openPf2(rank=rank, dataName="lupus", optProjs=True)
 
     # UMAP dimension reduction
-    pf2Points = openUMAP(40, "lupus", opt=True)
+    pf2Points = pacmap.PaCMAP().fit_transform(projs)
 
     plotCmpUMAP(cmp, factors[1], pf2Points, projs, ax[0])
     plotUMAP_obslabel(broad_type, pf2Points, ax[1])

--- a/sccp/figures/figureLupus3.py
+++ b/sccp/figures/figureLupus3.py
@@ -7,7 +7,7 @@ data: https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE174188
 # GOAL: visualize the component compostition by cell type
 import pacmap
 from .common import subplotLabel, getSetup, flattenWeightedProjs, openPf2, flattenData
-from .commonFuncs.plotUMAP import plotCmpPerCellType, plotCmpUMAP, plotCellTypeUMAP
+from .commonFuncs.plotUMAP import plotCmpPerCellType, plotCmpUMAP, points
 from ..imports.scRNA import load_lupus_data
 
 
@@ -43,9 +43,8 @@ def makeFigure():
     for i, comp in enumerate(comps):
         plotCmpPerCellType(weightedProjDF, comp, ax[(2*i)], outliers=False)
         plotCmpUMAP(comp, factors[1], pf2Points, projs, ax[(2*i)+1])
-    
 
-    plotCellTypeUMAP(pf2Points, dataDF, ax[14])
-
+    points(pf2Points, labels=dataDF["Cell Type"].values, ax=ax[14])
+    ax[14].set(ylabel="UMAP2", xlabel="UMAP1")
 
     return f

--- a/sccp/figures/figureLupus3.py
+++ b/sccp/figures/figureLupus3.py
@@ -5,7 +5,8 @@ data: https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE174188
 """
 
 # GOAL: visualize the component compostition by cell type
-from .common import subplotLabel, getSetup, flattenWeightedProjs, openPf2, openUMAP, flattenData
+import pacmap
+from .common import subplotLabel, getSetup, flattenWeightedProjs, openPf2, flattenData
 from .commonFuncs.plotUMAP import plotCmpPerCellType, plotCmpUMAP, plotCellTypeUMAP
 from ..imports.scRNA import load_lupus_data
 
@@ -31,12 +32,12 @@ def makeFigure():
         factors,
         projs,
     ) = openPf2(rank=rank, dataName="lupus", optProjs=True)
-    
-    pf2Points = openUMAP(rank, "lupus", opt=True)
 
     weightedProjDF = flattenWeightedProjs(lupus_tensor, factors[1], projs)
     weightedProjDF["Cell Type"] = cell_types["cell_type_broad"].values
     dataDF["Cell Type"] = cell_types["cell_type_broad"].values
+
+    pf2Points = pacmap.PaCMAP().fit_transform(projs)
 
     comps = [13, 14, 16, 26, 29, 32]
     for i, comp in enumerate(comps):

--- a/sccp/figures/figureThomson10.py
+++ b/sccp/figures/figureThomson10.py
@@ -5,7 +5,6 @@ from .common import (
     subplotLabel,
     getSetup,
     openPf2,
-    openUMAP,
     flattenData,
     flattenWeightedProjs,
 )

--- a/sccp/figures/figureThomson2.py
+++ b/sccp/figures/figureThomson2.py
@@ -11,9 +11,9 @@ from .common import (
 )
 from .commonFuncs.plotGeneral import plotGenePerCellType, plotGenePerCategCond
 from .commonFuncs.plotUMAP import (
-    plotCellTypeUMAP,
     plotCmpPerCellType,
     plotCmpUMAP,
+    points
 )
 from ..imports.scRNA import ThompsonXA_SCGenes
 from ..imports.gating import gateThomsonCells
@@ -38,7 +38,8 @@ def makeFigure():
     _, factors, projs = openPf2(rank, "Thomson")
     pf2Points = pacmap.PaCMAP().fit_transform(projs)
 
-    plotCellTypeUMAP(pf2Points, dataDF, ax[0])
+    points(pf2Points, labels=dataDF["Cell Type"].values, ax=ax[0])
+    ax[0].set(ylabel="UMAP2", xlabel="UMAP1")
 
     # weightedProjDF = flattenWeightedProjs(data, factors[1], projs)
     # weightedProjDF["Cell Type"] = dataDF["Cell Type"].values

--- a/sccp/figures/figureThomson2.py
+++ b/sccp/figures/figureThomson2.py
@@ -1,7 +1,7 @@
 """
 Parafac2 implementation on PBMCs treated wtih PopAlign/Thompson drugs
 """
-import umap
+import pacmap
 from .common import (
     subplotLabel,
     getSetup,
@@ -36,7 +36,7 @@ def makeFigure():
     dataDF["Cell Type"] = gateThomsonCells()
 
     _, factors, projs = openPf2(rank, "Thomson")
-    pf2Points = umap.UMAP(random_state=1, min_dist=.01).fit(projs)
+    pf2Points = pacmap.PaCMAP().fit_transform(projs)
 
     plotCellTypeUMAP(pf2Points, dataDF, ax[0])
 

--- a/sccp/figures/figureThomson3.py
+++ b/sccp/figures/figureThomson3.py
@@ -2,7 +2,7 @@
 Parafac2 implementation on PBMCs treated wtih PopAlign/Thompson drugs
 """
 import numpy as np
-import umap
+import pacmap
 from .common import subplotLabel, getSetup, openPf2, openPf2
 from .commonFuncs.plotUMAP import (
     plotCmpUMAP,
@@ -21,7 +21,7 @@ def makeFigure():
 
     # UMAP dimension reduction
     _, _, projs = openPf2(rank, "Thomson")
-    pf2Points = umap.UMAP(random_state=1).fit(projs)
+    pf2Points = pacmap.PaCMAP().fit_transform(projs)
 
     component = np.arange(17, 25, 1)
 

--- a/sccp/figures/figureThomson4.py
+++ b/sccp/figures/figureThomson4.py
@@ -1,11 +1,12 @@
 """
 Parafac2 implementation on PBMCs treated wtih PopAlign/Thompson drugs: investigating UMAP
 """
-import umap
+import numpy as np
 from sklearn.decomposition import PCA
 from .common import subplotLabel, getSetup, openPf2, flattenData
-from .commonFuncs.plotUMAP import plotGeneUMAP, plotCondUMAP
+from .commonFuncs.plotUMAP import plotGeneUMAP, points
 from ..imports.scRNA import ThompsonXA_SCGenes
+import pacmap
 
 
 def makeFigure():
@@ -17,18 +18,18 @@ def makeFigure():
     subplotLabel(ax)
 
     # Import of single cells: [Drug, Cell, Gene]
-    data = ThompsonXA_SCGenes(offset=1.0)
+    data = ThompsonXA_SCGenes()
     rank = 30
     dataDF = flattenData(data)
 
     # UMAP dimension reduction
     _, _, projs = openPf2(rank, "Thomson")
-    pf2Points = umap.UMAP(random_state=1).fit(projs)
+    pf2Points = pacmap.PaCMAP().fit_transform(projs)
 
     # PCA dimension reduction
     pc = PCA(n_components=rank)
     pcaPoints = pc.fit_transform(data.unfold())
-    pcaPoints = umap.UMAP(random_state=1).fit(pcaPoints)
+    pcaPoints = pacmap.PaCMAP().fit_transform(pcaPoints)
 
     genes = ["GNLY", "NKG7"]
     plotGeneUMAP(genes, "Pf2", pf2Points, dataDF, ax[0:2])
@@ -39,7 +40,28 @@ def makeFigure():
         "Triamcinolone Acetonide",
         "Alprostadil",
     ]
-    plotCondUMAP(drugs, "Pf2", dataDF["Condition"].values, pf2Points, ax[4:6])
-    plotCondUMAP(drugs, "PCA", dataDF["Condition"].values, pcaPoints, ax[6:8])
+    condList = np.array([c if c in drugs else " Other Conditions" for c in totalconds])
+
+    points(
+        pf2Points,
+        labels=condList,
+        ax=ax[4],
+        color_key_cmap="Paired",
+        show_legend=True,
+    )
+    ax[4].set(
+        title="Pf2-Based Decomposition", ylabel="UMAP2", xlabel="UMAP1"
+    )
+
+    points(
+        pcaPoints,
+        labels=condList,
+        ax=ax[5],
+        color_key_cmap="Paired",
+        show_legend=True,
+    )
+    ax[5].set(
+        title="PCA-Based Decomposition", ylabel="UMAP2", xlabel="UMAP1"
+    )
 
     return f

--- a/sccp/figures/figureThomson4.py
+++ b/sccp/figures/figureThomson4.py
@@ -40,7 +40,7 @@ def makeFigure():
         "Triamcinolone Acetonide",
         "Alprostadil",
     ]
-    condList = np.array([c if c in drugs else " Other Conditions" for c in totalconds])
+    condList = np.array([c if c in drugs else " Other Conditions" for c in dataDF["Condition"].values])
 
     points(
         pf2Points,

--- a/sccp/figures/figureThomson5.py
+++ b/sccp/figures/figureThomson5.py
@@ -2,7 +2,7 @@
 Parafac2 implementation on PBMCs treated wtih PopAlign/Thompson drugs: investigating UMAP
 """
 from ..imports.scRNA import ThompsonXA_SCGenes
-import umap
+import pacmap
 from sklearn.decomposition import PCA
 from .common import subplotLabel, getSetup, openPf2, flattenData
 
@@ -26,7 +26,7 @@ def makeFigure():
 
     # UMAP dimension reduction
     _, _, projs = openPf2(rank, "Thomson")
-    pf2Points = umap.UMAP(random_state=1).fit(projs)
+    pf2Points = pacmap.PaCMAP().fit_transform(projs)
 
     # Genes for cells
     cd4 = ["IL7R"]

--- a/sccp/figures/figureThomson5.py
+++ b/sccp/figures/figureThomson5.py
@@ -1,7 +1,6 @@
 """
 Parafac2 implementation on PBMCs treated wtih PopAlign/Thompson drugs: investigating UMAP
 """
-import numpy as np
 from ..imports.scRNA import ThompsonXA_SCGenes
 import umap
 from sklearn.decomposition import PCA
@@ -20,7 +19,7 @@ def makeFigure():
     subplotLabel(ax)
 
     # Import of single cells: [Drug, Cell, Gene]
-    data = ThompsonXA_SCGenes(offset=1.0)
+    data = ThompsonXA_SCGenes()
     rank = 30
 
     dataDF = flattenData(data)
@@ -39,7 +38,7 @@ def makeFigure():
     b = ["MS4A1", "CD79A"]
 
     plotGeneUMAP(
-        np.concatenate((cd4, cd8, nk, mono1, mono2, dc, b)),
+        cd4 + cd8 + nk + mono1 + mono2 + dc + b,
         "Pf2",
         pf2Points,
         dataDF,

--- a/sccp/imports/gating.py
+++ b/sccp/imports/gating.py
@@ -1,4 +1,4 @@
-import umap
+import pacmap
 import numpy as np
 import pandas as pd
 from ..figures.common import openPf2
@@ -8,7 +8,7 @@ def gateThomsonCells():
     """Manually gates cell types for Thomson UMAP"""
     _, _, projs = openPf2(30, "Thomson")
 
-    pf2Points = umap.UMAP(random_state=1).fit_transform(projs)
+    pf2Points = pacmap.PaCMAP().fit_transform(projs)
 
     umap1 = pf2Points[:, 0]
     umap2 = pf2Points[:, 1]

--- a/sccp/imports/gating.py
+++ b/sccp/imports/gating.py
@@ -1,7 +1,6 @@
 import umap
 import numpy as np
 import pandas as pd
-import umap.plot
 from ..figures.common import openPf2
 
 

--- a/sccp/imports/gating.py
+++ b/sccp/imports/gating.py
@@ -1,5 +1,4 @@
 import pacmap
-import numpy as np
 import pandas as pd
 from ..figures.common import openPf2
 
@@ -8,14 +7,13 @@ def gateThomsonCells():
     """Manually gates cell types for Thomson UMAP"""
     _, _, projs = openPf2(30, "Thomson")
 
-    pf2Points = pacmap.PaCMAP().fit_transform(projs)
+    pf2Points = pacmap.PaCMAP(random_state=1).fit_transform(projs)
 
     umap1 = pf2Points[:, 0]
     umap2 = pf2Points[:, 1]
 
-    cells = np.zeros(len(umap1))
-
-    df = pd.DataFrame(data={"UMAP1": umap1, "UMAP2": umap2, "Cell Type": cells})
+    df = pd.DataFrame(data={"UMAP1": umap1, "UMAP2": umap2})
+    df["Cell Type"] = "Monocytes"
 
     idx = df.index[(df["UMAP1"] >= 5)].tolist()
     df.loc[idx, "Cell Type"] = "DCs"


### PR DESCRIPTION
This PR switches all of the embedding to PaCMAP. I finally got around to listening to a talk on the method, and I am convinced we should use this instead. While the benefits in terms of embedding "global" vs. "local" structure can be gamed, PaCMAP is also beneficial in being much faster to calculate and a much better developed package. This method is also supposed to improve some of that "crowding" effect we have seen with cell types being smashed into a single dot.

Don't bother with switching figures over in the paper quite yet and, also, please do not add code to save the embedding. I have another large change coming that will save the Pf2 and embedding results all together in an anndata object, to greatly simplify more code.